### PR TITLE
Fix leftover files when scanning documents

### DIFF
--- a/DocumentsApp/ViewModels/DocumentViewModel.swift
+++ b/DocumentsApp/ViewModels/DocumentViewModel.swift
@@ -30,8 +30,10 @@ class DocumentViewModel: ObservableObject {
         
         do {
             let pdfData = try pdfGenerationService.generatePDF(from: scan)
-            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("Scanned_\(Date().timeIntervalSince1970).pdf")
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("Scanned_\(Date().timeIntervalSince1970).pdf")
             try pdfData.write(to: tempURL)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
             
             let document = Document(url: tempURL)
             document.data = pdfData


### PR DESCRIPTION
## Summary
- ensure temporary PDF files are removed after converting scanned pages

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569c8a4dc48325ab941c77d3bab02c