### PR TITLE
Fix checkSecurity sets recommendations unconditionally

### DIFF
--- a/DocumentsApp/ViewModels/DocumentViewModel.swift
+++ b/DocumentsApp/ViewModels/DocumentViewModel.swift
@@ -84,9 +84,7 @@ class DocumentViewModel: ObservableObject {
     
     func checkSecurity() {
         let recommendations = securityService.getSecurityRecommendations()
-        if !recommendations.isEmpty {
-            securityRecommendations = recommendations
-        }
+        securityRecommendations = recommendations
     }
     
     func fullfillSecurityRecomendations() {


### PR DESCRIPTION
## Summary
- set `securityRecommendations` to the retrieved list regardless of emptiness

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68569e6fc888832590c1f543be53bd14