### PR TITLE
Clarify preview initializer comment

### DIFF
--- a/DocumentsApp/Views/ContentView.swift
+++ b/DocumentsApp/Views/ContentView.swift
@@ -170,7 +170,8 @@ struct ContentView: View {
     }
 }
 
-// Add a convenience initializer that uses the environment
+// Add a convenience initializer used in previews
+// that creates a default model context instead of relying on the environment
 extension ContentView {
     init() {
         // This will be called when the view is created in the preview


### PR DESCRIPTION
## Summary
- clarify that the extension initializer creates a default model context for previews

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68569e8c23ac832588bc7f2a62aa292e