### PR TITLE
Add Document model tests

### DIFF
--- a/DocumentsAppTests/DocumentsAppTests.swift
+++ b/DocumentsAppTests/DocumentsAppTests.swift
@@ -6,11 +6,31 @@
 //
 
 import Testing
+@testable import DocumentsApp
 
 struct DocumentsAppTests {
 
     @Test func example() async throws {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+    @Test func documentBehaviors() async throws {
+        // Prepare known data
+        let data = Data(repeating: 0xFF, count: 2048)
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("Test.pdf")
+        try data.write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let document = Document(url: tempURL)
+
+        // Verify basic properties
+        #expect(document.name == "Test.pdf")
+        #expect(document.fileSize == 2048)
+        #expect(document.formattedFileSize == "2 KB")
+
+        // Verify data retrieval
+        let retrieved = try document.getData()
+        #expect(retrieved == data)
     }
 
 }


### PR DESCRIPTION
## Summary
- add `DocumentsApp` module to test target via `@testable import`
- implement `documentBehaviors` unit test

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68569e953ebc8325bd1d71b5cff68e0a